### PR TITLE
Add Docker support for video-processing-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # YouTube Clone
 
 This repository hosts the source code for a YouTube clone. The core component of this project is the `video-processing-service`, which handles video file processing.
@@ -19,45 +18,69 @@ What things you need to install the software and how to install them:
 node --version
 npm --version
 ffmpeg -version  # Fluent FFmpeg requires FFmpeg to be installed
+docker --version
 ```
 
 ### Installation
 
 1. **Clone the repository**:
-   ```sh
-   git clone https://github.com/Reddimus/youtube-clone.git
-   ```
+	 ```sh
+	 git clone https://github.com/Reddimus/youtube-clone.git
+	 ```
 
 2. **Navigate to the service directory**:
-   ```sh
-   cd youtube-clone/video-processing-service
-   ```
+	 ```sh
+	 cd video-processing-service
+	 ```
 
-3. **Install dependencies**:
-   ```sh
-   npm install
-   ```
+3. **Build the Docker image**:
+	 ```sh
+	 docker build -t video-processing-service .
+	 ```
+
+Docker will ensure that the application runs with all necessary dependencies, regardless of the host environment.
 
 ### Running the Service
 
-- **Start the server**:
-  ```sh
-  npm start
-  ```
+1. **Start the server on port 3000**:
+	```sh
+	docker run -p 3000:3000 -d video-processing-service
+	```
+2. **Find the container ID**:
+	```sh
+	docker ps
+	```
+3. **Copy a local video file into the docker container**:
+	```sh
+	docker cp ./video.mp4 <container_id>:/app/processed-video.mp4
+	```
+4. **POST a request to http://localhost:3000/process-video**:  
+	Body (JSON):
+	```json
+	{
+		"inputFilePath": "./video.mp4", 
+		"outputFilePath": "./processed-video.mp4"
+	}
+	```
+	> Recommended: Use Thunder Client or Postman to send the request.
+5. **Copy our processed video file out of the Docker container**:
+	```sh
+	docker cp <container_id>:/app/processed-video.mp4 ./
+	```
 
-  This will start the service on `localhost:3000` by default. You can modify the `PORT` environment variable in your configuration file or directly in your terminal to use a different port.
+This will start the service on `localhost:3000` by default. You can modify the `PORT` environment variable in your configuration file or directly in your terminal to use a different port.
 
 ## API Reference
 
 The service exposes the following endpoint for video processing:
 
 - **POST /process-video**:
-  - **Purpose**: Processes a video file.
-  - **Request Body**:
-    ```json
-    {
-      "inputFilePath": "path/to/input.mp4",
-      "outputFilePath": "path/to/output.mp4"
-    }
-    ```
-  - **Response**: A status message indicating the success or failure of the video processing.
+	- **Purpose**: Processes a video file.
+	- **Request Body**:
+		```json
+		{
+			"inputFilePath": "path/to/input.mp4",
+			"outputFilePath": "path/to/output.mp4"
+		}
+		```
+	- **Response**: A status message indicating the success or failure of the video processing.

--- a/video-processing-service/.dockerignore
+++ b/video-processing-service/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/video-processing-service/Dockerfile
+++ b/video-processing-service/Dockerfile
@@ -1,0 +1,41 @@
+# Stage 1: Build stage
+FROM node:20 AS builder
+
+# Set the working directory in the container to /app
+WORKDIR /app
+
+# Copy package.json and package-lock.json into the working directory
+COPY package*.json ./
+
+# Install any needed packages specified in package.json
+RUN npm install
+
+# Bundle app source inside the docker image
+COPY . .
+
+# Build the app
+RUN npm run build
+
+# Stage 2: Production stage
+FROM node:20
+
+# Install ffmpeg in the container
+RUN apt-get update && apt-get install -y ffmpeg
+
+# Set the working directory
+WORKDIR /app
+
+# Copy package.json and package-lock.json
+COPY package*.json ./
+
+# Install only production dependencies
+RUN npm install --only=production
+
+# Copy built app from the builder stage
+COPY --from=builder /app/dist ./dist
+
+# Make port 3000 available to the world outside this container
+EXPOSE 3000
+
+# Define the command to run your app using CMD which defines your runtime
+CMD [ "npm", "run", "serve" ]


### PR DESCRIPTION
This pull request adds Docker support for the video-processing-service. Docker allows the application to be built and run in a containerized environment, ensuring consistent dependencies and easier deployment. The Dockerfile has been added to the repository, along with instructions for building and running the service using Docker. This will make it easier for developers to set up and run the application in different environments.