### PR TITLE
Fix typo in Docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Docker will ensure that the application runs with all necessary dependencies, re
 	```
 3. **Copy a local video file into the docker container**:
 	```sh
-	docker cp ./video.mp4 <container_id>:/app/processed-video.mp4
+	docker cp ./video.mp4 <container_id>:/app/video.mp4
 	```
 4. **POST a request to http://localhost:3000/process-video**:  
 	Body (JSON):


### PR DESCRIPTION
Fixed a typo in the Docker command that copies a local video file into the container. The file name was incorrect, causing the file to not be copied properly. This PR corrects the file name in the command to ensure that the video file is copied successfully.